### PR TITLE
Added nope/yep buttons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 node_modules/
 npm-debug.log
+.idea

--- a/SwipeCards.js
+++ b/SwipeCards.js
@@ -228,7 +228,7 @@ class SwipeCards extends Component {
   _renderButton(renderFunc, onPress) {
     if (renderFunc) {
       return (
-        <TouchableOpacity onPress={onPress}>
+        <TouchableOpacity disabled={!this.state.card} onPress={onPress}>
           {renderFunc()}
         </TouchableOpacity>
       )
@@ -289,10 +289,15 @@ class SwipeCards extends Component {
           )
         }
       
-        <View style={[styles.buttonContainerStyle, this.props.buttonContainerStyle]}>
-          {this._renderButton(this.props.renderNopeButton, this._onNopePress.bind(this))}
-          {this._renderButton(this.props.renderYupButton, this._onYupPress.bind(this))}
-        </View>
+        { this.state.card  ?
+          
+          <View style={[styles.buttonContainerStyle, this.props.buttonContainerStyle]}>
+            {this._renderButton(this.props.renderNopeButton, this._onNopePress.bind(this))}
+            {this._renderButton(this.props.renderYupButton, this._onYupPress.bind(this))}
+          </View>
+          
+          : null
+        }
     
       </View>
     );

--- a/SwipeCards.js
+++ b/SwipeCards.js
@@ -63,7 +63,7 @@ var styles = StyleSheet.create({
 class SwipeCards extends Component {
   static propTypes = {
     cards: React.PropTypes.array,
-    renderCards: React.PropTypes.func,
+    renderCard: React.PropTypes.func,
     loop: React.PropTypes.bool,
     renderNoMoreCards: React.PropTypes.func,
     renderYupButton: React.PropTypes.func,

--- a/SwipeCards.js
+++ b/SwipeCards.js
@@ -77,6 +77,7 @@ class SwipeCards extends Component {
     yupText: React.PropTypes.string,
     noText: React.PropTypes.string,
     containerStyle: View.propTypes.style,
+    cardViewStyle: View.propTypes.style,
     buttonContainerStyle: View.propTypes.style,
     yupStyle: View.propTypes.style,
     yupTextStyle: Text.propTypes.style,
@@ -268,7 +269,7 @@ class SwipeCards extends Component {
       <View style={this.props.containerStyle}>
         { this.state.card
           ? (
-          <Animated.View style={[styles.card, animatedCardstyles]} {...this._panResponder.panHandlers}>
+          <Animated.View style={[this.props.cardViewStyle, animatedCardstyles]} {...this._panResponder.panHandlers}>
             {this.renderCard(this.state.card)}
           </Animated.View>
         )

--- a/SwipeCards.js
+++ b/SwipeCards.js
@@ -10,13 +10,15 @@ import {
     Animated,
     PanResponder,
     TouchableOpacity,
+    Dimensions,
 } from 'react-native';
 
 import clamp from 'clamp';
 
 import Defaults from './Defaults.js';
 
-var SWIPE_THRESHOLD = 120;
+const SWIPE_THRESHOLD = 120;
+const SCREEN_WIDTH = Dimensions.get('window').width;
 
 // Base Styles. Use props to override these values
 var styles = StyleSheet.create({
@@ -162,19 +164,23 @@ class SwipeCards extends Component {
         }
 
         if (Math.abs(this.state.pan.x._value) > SWIPE_THRESHOLD) {
-
-          this.state.pan.x._value > 0
-            ? this.props.handleYup(this.state.card)
-            : this.props.handleNope(this.state.card)
-
-          this.props.cardRemoved
-            ? this.props.cardRemoved(this.props.cards.indexOf(this.state.card))
-            : null
+          
+          this.props.cardRemoved &&
+          this.props.cardRemoved(this.props.cards.indexOf(this.state.card));
 
           Animated.decay(this.state.pan, {
             velocity: {x: velocity, y: vy},
             deceleration: 0.98
-          }).start(this._resetState.bind(this))
+          }).start(()=> {
+            
+            // After animation
+            this.state.pan.x._value > 0 ?
+              this.props.handleYup(this.state.card) :
+              this.props.handleNope(this.state.card);
+            
+            this._resetState()
+          })
+          
         } else {
           Animated.spring(this.state.pan, {
             toValue: {x: 0, y: 0},
@@ -193,23 +199,27 @@ class SwipeCards extends Component {
   }
   
   _onYupPress() {
-    this.props.handleYup(this.state.card);
     this.props.cardRemoved
       ? this.props.cardRemoved(this.props.cards.indexOf(this.state.card))
       : null;
     Animated.timing(this.state.pan, {
-      toValue: {x: 1000, y: 0},
-    }).start(this._resetState.bind(this));
+      toValue: {x: SCREEN_WIDTH + 50, y: 0},
+    }).start(()=> {
+      this.props.handleYup(this.state.card);
+      this._resetState();
+    });
   }
   
   _onNopePress() {
-    this.props.handleNope(this.state.card);
     this.props.cardRemoved
       ? this.props.cardRemoved(this.props.cards.indexOf(this.state.card))
       : null;
     Animated.timing(this.state.pan, {
-      toValue: {x: -1000, y: 0},
-    }).start(this._resetState.bind(this));
+      toValue: {x: -SCREEN_WIDTH - 50, y: 0},
+    }).start(()=> {
+      this.props.handleNope(this.state.card);
+      this._resetState();
+    });
   }
   
   renderNoMoreCards() {

--- a/SwipeCards.js
+++ b/SwipeCards.js
@@ -55,6 +55,35 @@ var styles = StyleSheet.create({
 });
 
 class SwipeCards extends Component {
+  static propTypes = {
+    cards: React.PropTypes.array,
+    renderCards: React.PropTypes.func,
+    loop: React.PropTypes.bool,
+    renderNoMoreCards: React.PropTypes.func,
+    showYup: React.PropTypes.bool,
+    showNope: React.PropTypes.bool,
+    handleYup: React.PropTypes.func,
+    handleNope: React.PropTypes.func,
+    yupText: React.PropTypes.string,
+    noText: React.PropTypes.string,
+    containerStyle: View.propTypes.style,
+    yupStyle: View.propTypes.style,
+    yupTextStyle: Text.propTypes.style,
+    nopeStyle: View.propTypes.style,
+    nopeTextStyle: Text.propTypes.style
+  }
+  
+  static defaultProps = {
+    loop: false,
+    showYup: true,
+    showNope: true,
+    containerStyle: styles.container,
+    yupStyle: styles.yup,
+    yupTextStyle: styles.yupText,
+    nopeStyle: styles.nope,
+    nopeTextStyle: styles.nopeText
+  }
+  
   constructor(props) {
     super(props);
 
@@ -227,34 +256,5 @@ class SwipeCards extends Component {
     );
   }
 }
-
-SwipeCards.propTypes = {
-    cards: React.PropTypes.array,
-    renderCards: React.PropTypes.func,
-    loop: React.PropTypes.bool,
-    renderNoMoreCards: React.PropTypes.func,
-    showYup: React.PropTypes.bool,
-    showNope: React.PropTypes.bool,
-    handleYup: React.PropTypes.func,
-    handleNope: React.PropTypes.func,
-    yupText: React.PropTypes.string,
-    noText: React.PropTypes.string,
-    containerStyle: View.propTypes.style,
-    yupStyle: View.propTypes.style,
-    yupTextStyle: Text.propTypes.style,
-    nopeStyle: View.propTypes.style,
-    nopeTextStyle: Text.propTypes.style
-};
-
-SwipeCards.defaultProps = {
-    loop: false,
-    showYup: true,
-    showNope: true,
-    containerStyle: styles.container,
-    yupStyle: styles.yup,
-    yupTextStyle: styles.yupText,
-    nopeStyle: styles.nope,
-    nopeTextStyle: styles.nopeText
-};
 
 export default SwipeCards

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-swipe-cards",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Tinder style swipe cards for stylishly passing, failing a card",
   "main": "SwipeCards.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-swipe-cards",
-  "version": "0.0.9",
+  "version": "1.0.0",
   "description": "Tinder style swipe cards for stylishly passing, failing a card",
   "main": "SwipeCards.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-swipe-cards",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Tinder style swipe cards for stylishly passing, failing a card",
   "main": "SwipeCards.js",
   "scripts": {


### PR DESCRIPTION
This PR is based on an old PR by @kn4rfy. I haven't included the back button like he did because it is of no use for me. My implementation adds custom render props to the swipe cards component.

Example Usage:

```
renderYupButton() {
    console.log("Rendering");
    return (
      <View style={[styles.roundButton, {backgroundColor: ColorConstants.emerald}]}>
        <Icon name="heart" size={35} color="white"/>
      </View>
    );
  }

  renderNopeButton() {
    return (
      <View style={[styles.roundButton, {backgroundColor: ColorConstants.darkishRed}]}>
        <Icon name="times" size={45} color="white" style={{paddingBottom: 2, paddingRight: 1,}}/>
      </View>
    );
  }

render() {
        return (
      <SwipeCards
        cards={this.props.cardDataList}
        renderCard={(cardData) => <Card {...cardData} />}
        renderNoMoreCards={() => <NoMoreCards />}
        handleYup={(card)=>this.props.onSwipe(card.id, true)}
        handleNope={(card)=>this.props.onSwipe(card.id, false)}
        showNope={false} showYup={false}
        renderYupButton={this.renderYupButton}
        renderNopeButton={this.renderNopeButton}
        containerStyle={styles.container}
        buttonContainerStyle={styles.buttonsContainer}
        loop={this.props.loop}
      />
    )
```

<img width="371" alt="screen shot 2016-07-26 at 16 12 58" src="https://cloud.githubusercontent.com/assets/2580920/17139149/e8633ec6-534b-11e6-9ed9-d29c7b220f0a.png">
